### PR TITLE
test 예약/취소 통합·동시성 테스트 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,11 @@ dependencies {
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
+	// Testcontainers (실제 MySQL 기반 통합 테스트 - 비관적 락/멱등성/동시성 충실 검증)
+	testImplementation("org.springframework.boot:spring-boot-testcontainers")
+	testImplementation("org.testcontainers:junit-jupiter")
+	testImplementation("org.testcontainers:mysql")
+
 	// Mysql 의존성
 	implementation("mysql:mysql-connector-java:8.0.33")
 

--- a/src/test/kotlin/com/example/reserve/KotlinApplicationTests.kt
+++ b/src/test/kotlin/com/example/reserve/KotlinApplicationTests.kt
@@ -1,8 +1,0 @@
-package com.example.reserve
-
-import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-
-@SpringBootTest
-class KotlinApplicationTests {
-}

--- a/src/test/kotlin/com/example/reserve/ReserveApplicationTests.kt
+++ b/src/test/kotlin/com/example/reserve/ReserveApplicationTests.kt
@@ -1,8 +1,0 @@
-package com.example.reserve
-
-import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-
-@SpringBootTest
-class ReserveApplicationTests {
-}

--- a/src/test/kotlin/com/example/reserve/reserve/ReserveConcurrencyTest.kt
+++ b/src/test/kotlin/com/example/reserve/reserve/ReserveConcurrencyTest.kt
@@ -1,0 +1,160 @@
+package com.example.reserve.reserve
+
+import com.example.reserve.reserve.dto.ReserveRequest
+import com.example.reserve.reserveException.ErrorCode
+import com.example.reserve.reserveException.ReserveException
+import com.example.reserve.support.IntegrationTestSupport
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+/**
+ * 동시성 레이스 검증
+ * 모든 스레드를 start 래치로 동시에 출발시키고, 각 작업의 예외(또는 null=성공)를 수집해 검증
+ * @Transactional 롤백을 쓰지 않으므로 각 스레드는 실제 커밋되고, 락/조건부 UPDATE가 실제로 동작
+ */
+class ReserveConcurrencyTest : IntegrationTestSupport() {
+
+    @Autowired private lateinit var reserveService: ReserveService
+    @Autowired private lateinit var reserveApplicationService: ReserveApplicationService
+
+    @Test
+    @DisplayName("같은 좌석 10명 동시 예약 - 정확히 1건만 성공 (조건부 UPDATE)")
+    fun `같은 좌석 동시 예약`() {
+        val n = 10
+        repeat(n) { saveMember("user$it", credit = 300_000) }
+        val scheduleId = saveScheduleWithSeats(price = 10_000, seatNumbers = listOf("A1"))
+
+        val errors = runConcurrently(n) { i ->
+            reserveService.reserve(
+                ReserveRequest(
+                    reservationNumber = UUID.randomUUID().toString(),
+                    seatNumbers = listOf("A1"),
+                    performanceScheduleId = scheduleId,
+                ),
+                "user$i",
+            )
+        }
+
+        val successCount = errors.count { it == null }
+        assertThat(successCount).isEqualTo(1)
+        // 실패는 모두 좌석 선점 충돌
+        assertThat(errors.filterNotNull().map { (it as ReserveException).errorCode })
+            .containsOnly(ErrorCode.SEAT_ALREADY_RESERVED)
+            .hasSize(n - 1)
+        // 좌석은 점유되고 예약은 1건만
+        assertThat(isSeatReserved(scheduleId, "A1")).isTrue()
+        assertThat(reserveRepository.findAll().count { it.status == ReserveStatus.RESERVED }).isEqualTo(1)
+    }
+
+    @Test
+    @DisplayName("같은 회원 동시 예약 - 크레딧 한도 내에서만 성공, 초과 차감/음수 없음 (회원 비관적 락)")
+    fun `같은 회원 동시 예약 - 크레딧 직렬화`() {
+        val n = 10
+        // 단가 10_000, 크레딧 25_000 -> 최대 2건만 가능
+        saveMember("alice", credit = 25_000)
+        val seats = (1..n).map { "S$it" }
+        val scheduleId = saveScheduleWithSeats(price = 10_000, seatNumbers = seats)
+
+        val errors = runConcurrently(n) { i ->
+            reserveService.reserve(
+                ReserveRequest(
+                    reservationNumber = UUID.randomUUID().toString(),
+                    seatNumbers = listOf(seats[i]),
+                    performanceScheduleId = scheduleId,
+                ),
+                "alice",
+            )
+        }
+
+        val successCount = errors.count { it == null }
+        assertThat(successCount).isEqualTo(2)
+        // 나머지는 잔액 부족 (lost update가 있었다면 더 많이 성공하거나 크레딧이 음수가 됨)
+        assertThat(errors.filterNotNull().map { (it as ReserveException).errorCode })
+            .containsOnly(ErrorCode.NOT_ENOUGH_CREDIT)
+        assertThat(creditOf("alice")).isEqualTo(5_000)
+        assertThat(reserveRepository.findAll().count { it.status == ReserveStatus.RESERVED }).isEqualTo(2)
+    }
+
+    @Test
+    @DisplayName("같은 예약 2건 동시 취소 - 1건만 성공, 환불 1회 (예약 비관적 락 + 상태 가드)")
+    fun `같은 예약 동시 취소`() {
+        saveMember("alice", credit = 300_000)
+        val scheduleId = saveScheduleWithSeats(price = 10_000, seatNumbers = listOf("A1"))
+        val rn = UUID.randomUUID().toString()
+        reserveService.reserve(
+            ReserveRequest(reservationNumber = rn, seatNumbers = listOf("A1"), performanceScheduleId = scheduleId),
+            "alice",
+        )
+        assertThat(creditOf("alice")).isEqualTo(290_000)
+
+        val errors = runConcurrently(2) { reserveService.cancelReserve(rn, "alice") }
+
+        val successCount = errors.count { it == null }
+        assertThat(successCount).isEqualTo(1)
+        assertThat(errors.filterNotNull().map { (it as ReserveException).errorCode })
+            .containsOnly(ErrorCode.ALREADY_CANCELLED)
+        // 환불은 정확히 1회 (이중 환불이면 310_000이 됨)
+        assertThat(creditOf("alice")).isEqualTo(300_000)
+        assertThat(isSeatReserved(scheduleId, "A1")).isFalse()
+    }
+
+    @Test
+    @DisplayName("같은 멱등성 키 10건 동시 진입 - 예약은 1건만 생성 (unique INSERT 상호배제)")
+    fun `같은 멱등성 키 동시 진입`() {
+        val n = 10
+        saveMember("alice", credit = 300_000)
+        val scheduleId = saveScheduleWithSeats(price = 10_000, seatNumbers = listOf("A1"))
+        // 동일 요청 + 동일 키
+        val req = ReserveRequest(
+            reservationNumber = UUID.randomUUID().toString(),
+            seatNumbers = listOf("A1"),
+            performanceScheduleId = scheduleId,
+        )
+        val key = "concurrent-idem-key"
+
+        runConcurrently(n) { reserveApplicationService.reserveSeat(req, "alice", key) }
+
+        // 멱등성으로 실제 실행은 1번뿐 -> 예약 1건, 크레딧 1회 차감
+        assertThat(reserveRepository.findAll().count { it.status == ReserveStatus.RESERVED }).isEqualTo(1)
+        assertThat(creditOf("alice")).isEqualTo(290_000)
+        assertThat(isSeatReserved(scheduleId, "A1")).isTrue()
+    }
+
+    /**
+     * count개의 작업을 동시에 출발시켜 실행하고, 인덱스별 throwable(성공 시 null)을 반환한다.
+     */
+    private fun runConcurrently(count: Int, block: (Int) -> Unit): List<Throwable?> {
+        val executor = Executors.newFixedThreadPool(count)
+        val ready = CountDownLatch(count)
+        val start = CountDownLatch(1)
+        val done = CountDownLatch(count)
+        val errors = arrayOfNulls<Throwable>(count)
+        try {
+            repeat(count) { i ->
+                executor.submit {
+                    ready.countDown()
+                    start.await()
+                    try {
+                        block(i)
+                    } catch (t: Throwable) {
+                        errors[i] = t
+                    } finally {
+                        done.countDown()
+                    }
+                }
+            }
+            ready.await()
+            start.countDown() // 동시 출발
+            check(done.await(60, TimeUnit.SECONDS)) { "동시 작업이 제한 시간 내에 끝나지 않음" }
+        } finally {
+            executor.shutdownNow()
+        }
+        return errors.toList()
+    }
+}

--- a/src/test/kotlin/com/example/reserve/reserve/ReserveServiceTest.kt
+++ b/src/test/kotlin/com/example/reserve/reserve/ReserveServiceTest.kt
@@ -1,0 +1,245 @@
+package com.example.reserve.reserve
+
+import com.example.reserve.reserve.dto.ReserveRequest
+import com.example.reserve.reserveException.ErrorCode
+import com.example.reserve.reserveException.ReserveException
+import com.example.reserve.support.IntegrationTestSupport
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * 예약/취소 비즈니스 로직 단일스레드 시나리오 검증
+ * 비즈니스 예외는 reserveService를 직접 호출해 ReserveException으로 확인하고, 멱등성 동작은 reserveApplicationService(ResponseEntity)로 확인
+ */
+class ReserveServiceTest : IntegrationTestSupport() {
+
+    @Autowired private lateinit var reserveService: ReserveService
+    @Autowired private lateinit var reserveApplicationService: ReserveApplicationService
+
+    private fun request(
+        scheduleId: Long,
+        seatNumbers: List<String>,
+        rewardDiscountAmount: Long = 0,
+        reservationNumber: String = UUID.randomUUID().toString(),
+    ) = ReserveRequest(
+        reservationNumber = reservationNumber,
+        rewardDiscountAmount = rewardDiscountAmount,
+        seatNumbers = seatNumbers,
+        performanceScheduleId = scheduleId,
+    )
+
+    // ---------- 예약 ----------
+    @Test
+    @DisplayName("예약 성공 - 좌석 점유, 크레딧 차감, RESERVED 예약 생성")
+    fun `예약 성공`() {
+        saveMember("alice", credit = 300_000)
+        val scheduleId = saveScheduleWithSeats(price = 10_000, seatNumbers = listOf("A1", "A2"))
+
+        reserveService.reserve(request(scheduleId, listOf("A1", "A2")), "alice")
+
+        assertThat(creditOf("alice")).isEqualTo(280_000)
+        assertThat(isSeatReserved(scheduleId, "A1")).isTrue()
+        assertThat(isSeatReserved(scheduleId, "A2")).isTrue()
+
+        val reserves = reserveRepository.findByMemberUsernameAndStatus("alice", ReserveStatus.RESERVED)
+        assertThat(reserves).hasSize(1)
+        assertThat(reserves[0].totalAmount).isEqualTo(20_000)
+        assertThat(reserves[0].finalAmount).isEqualTo(20_000)
+        assertThat(reserves[0].rewardDiscountAmount).isEqualTo(0)
+    }
+
+    @Test
+    @DisplayName("예약 성공 - 리워드 할인 적용 시 크레딧/리워드 모두 차감")
+    fun `리워드 할인 적용`() {
+        saveMember("bob", credit = 300_000, reward = 5_000)
+        val scheduleId = saveScheduleWithSeats(price = 10_000, seatNumbers = listOf("B1"))
+
+        reserveService.reserve(request(scheduleId, listOf("B1"), rewardDiscountAmount = 5_000), "bob")
+
+        // total=10_000, rewardDiscount=min(5_000,10_000,5_000)=5_000, final=5_000
+        assertThat(creditOf("bob")).isEqualTo(295_000)
+        assertThat(rewardOf("bob")).isEqualTo(0)
+
+        val reserve = reserveRepository.findByMemberUsernameAndStatus("bob", ReserveStatus.RESERVED).single()
+        assertThat(reserve.rewardDiscountAmount).isEqualTo(5_000)
+        assertThat(reserve.finalAmount).isEqualTo(5_000)
+    }
+
+    @Test
+    @DisplayName("예약 성공 - 요청 리워드가 보유분을 초과하면 보유분까지만 사용")
+    fun `리워드 할인 캡 적용`() {
+        saveMember("carol", credit = 300_000, reward = 3_000)
+        val scheduleId = saveScheduleWithSeats(price = 10_000, seatNumbers = listOf("C1"))
+
+        // 999_999 요청해도 보유 3_000까지만
+        reserveService.reserve(request(scheduleId, listOf("C1"), rewardDiscountAmount = 999_999), "carol")
+
+        assertThat(rewardOf("carol")).isEqualTo(0)
+        assertThat(creditOf("carol")).isEqualTo(293_000) // final = 10_000 - 3_000 = 7_000 차감
+    }
+
+    @Test
+    @DisplayName("예약 실패 - 잔액 부족 시 NOT_ENOUGH_CREDIT, 전체 롤백")
+    fun `잔액 부족`() {
+        saveMember("poor", credit = 5_000)
+        val scheduleId = saveScheduleWithSeats(price = 10_000, seatNumbers = listOf("D1"))
+
+        val ex = assertThrows<ReserveException> {
+            reserveService.reserve(request(scheduleId, listOf("D1")), "poor")
+        }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.NOT_ENOUGH_CREDIT)
+
+        // 롤백 확인: 크레딧 그대로, 좌석 미점유, 예약 없음
+        assertThat(creditOf("poor")).isEqualTo(5_000)
+        assertThat(isSeatReserved(scheduleId, "D1")).isFalse()
+        assertThat(reserveRepository.findByMemberUsernameAndStatus("poor", ReserveStatus.RESERVED)).isEmpty()
+    }
+
+    @Test
+    @DisplayName("예약 실패 - 이미 예약된 좌석은 SEAT_ALREADY_RESERVED")
+    fun `이미 예약된 좌석`() {
+        saveMember("alice", credit = 300_000)
+        saveMember("bob", credit = 300_000)
+        val scheduleId = saveScheduleWithSeats(price = 10_000, seatNumbers = listOf("E1"))
+
+        reserveService.reserve(request(scheduleId, listOf("E1")), "alice")
+
+        val ex = assertThrows<ReserveException> {
+            reserveService.reserve(request(scheduleId, listOf("E1")), "bob")
+        }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.SEAT_ALREADY_RESERVED)
+
+        assertThat(creditOf("bob")).isEqualTo(300_000) // 실패자 크레딧 미차감
+        assertThat(reserveRepository.findByMemberUsernameAndStatus("bob", ReserveStatus.RESERVED)).isEmpty()
+    }
+
+    @Test
+    @DisplayName("예약 실패 - 존재하지 않는 좌석은 NOT_EXIST_SEAT_INFO")
+    fun `존재하지 않는 좌석`() {
+        saveMember("alice", credit = 300_000)
+        val scheduleId = saveScheduleWithSeats(price = 10_000, seatNumbers = listOf("F1"))
+
+        val ex = assertThrows<ReserveException> {
+            reserveService.reserve(request(scheduleId, listOf("Z9")), "alice")
+        }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.NOT_EXIST_SEAT_INFO)
+        assertThat(creditOf("alice")).isEqualTo(300_000)
+    }
+
+    // ---------- 취소 ----------
+    @Test
+    @DisplayName("취소 성공 - 상태 CANCELLED, 좌석 release, 크레딧/리워드 환불")
+    fun `취소 성공`() {
+        saveMember("alice", credit = 300_000, reward = 5_000)
+        val scheduleId = saveScheduleWithSeats(price = 10_000, seatNumbers = listOf("A1"))
+        val rn = UUID.randomUUID().toString()
+        reserveService.reserve(request(scheduleId, listOf("A1"), rewardDiscountAmount = 5_000, reservationNumber = rn), "alice")
+        // 예약 후: credit 295_000, reward 0
+        assertThat(creditOf("alice")).isEqualTo(295_000)
+
+        reserveService.cancelReserve(rn, "alice")
+
+        // 환불 확인
+        assertThat(creditOf("alice")).isEqualTo(300_000)
+        assertThat(rewardOf("alice")).isEqualTo(5_000)
+        // 좌석 해제
+        assertThat(isSeatReserved(scheduleId, "A1")).isFalse()
+        // 상태 CANCELLED + cancelledAt
+        assertThat(reserveRepository.findByMemberUsernameAndStatus("alice", ReserveStatus.RESERVED)).isEmpty()
+        val cancelled = reserveRepository.findByMemberUsernameAndStatus("alice", ReserveStatus.CANCELLED).single()
+        assertThat(cancelled.cancelledAt).isNotNull()
+    }
+
+    @Test
+    @DisplayName("취소 실패 - 이미 취소된 예약은 ALREADY_CANCELLED, 이중 환불 없음")
+    fun `중복 취소`() {
+        saveMember("alice", credit = 300_000)
+        val scheduleId = saveScheduleWithSeats(price = 10_000, seatNumbers = listOf("A1"))
+        val rn = UUID.randomUUID().toString()
+        reserveService.reserve(request(scheduleId, listOf("A1"), reservationNumber = rn), "alice")
+
+        reserveService.cancelReserve(rn, "alice")
+        assertThat(creditOf("alice")).isEqualTo(300_000)
+
+        val ex = assertThrows<ReserveException> { reserveService.cancelReserve(rn, "alice") }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.ALREADY_CANCELLED)
+        // 이중 환불 없음
+        assertThat(creditOf("alice")).isEqualTo(300_000)
+    }
+
+    @Test
+    @DisplayName("취소 실패 - 타인 예약 취소 시 UNAUTHORIZED_ACCESS")
+    fun `타인 예약 취소`() {
+        saveMember("alice", credit = 300_000)
+        saveMember("bob", credit = 300_000)
+        val scheduleId = saveScheduleWithSeats(price = 10_000, seatNumbers = listOf("A1"))
+        val rn = UUID.randomUUID().toString()
+        reserveService.reserve(request(scheduleId, listOf("A1"), reservationNumber = rn), "alice")
+
+        val ex = assertThrows<ReserveException> { reserveService.cancelReserve(rn, "bob") }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.UNAUTHORIZED_ACCESS)
+
+        // 예약 유지, alice 크레딧 미환불
+        assertThat(reserveRepository.findByMemberUsernameAndStatus("alice", ReserveStatus.RESERVED)).hasSize(1)
+        assertThat(creditOf("alice")).isEqualTo(290_000)
+    }
+
+    @Test
+    @DisplayName("취소 실패 - 존재하지 않는 예약번호는 NOT_EXIST_RESERVE_INFO")
+    fun `존재하지 않는 예약 취소`() {
+        saveMember("alice", credit = 300_000)
+
+        val ex = assertThrows<ReserveException> { reserveService.cancelReserve("no-such-number", "alice") }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.NOT_EXIST_RESERVE_INFO)
+    }
+
+    @Test
+    @DisplayName("취소 실패 - 공연 시작 이후에는 CANCEL_NOT_ALLOWED_AFTER_START, 환불 없음")
+    fun `공연 시작 후 취소 차단`() {
+        saveMember("alice", credit = 300_000)
+        // 이미 시작한(과거) 공연
+        val scheduleId = saveScheduleWithSeats(
+            price = 10_000,
+            seatNumbers = listOf("A1"),
+            startTime = LocalDateTime.now().minusDays(1),
+        )
+        val rn = UUID.randomUUID().toString()
+        // 예약 자체는 시작시간을 검증하지 않으므로 성공
+        reserveService.reserve(request(scheduleId, listOf("A1"), reservationNumber = rn), "alice")
+        assertThat(creditOf("alice")).isEqualTo(290_000)
+
+        val ex = assertThrows<ReserveException> { reserveService.cancelReserve(rn, "alice") }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.CANCEL_NOT_ALLOWED_AFTER_START)
+
+        // 롤백 확인: 환불 안 됨, 예약 유지, 좌석 점유 유지
+        assertThat(creditOf("alice")).isEqualTo(290_000)
+        assertThat(reserveRepository.findByMemberUsernameAndStatus("alice", ReserveStatus.RESERVED)).hasSize(1)
+        assertThat(isSeatReserved(scheduleId, "A1")).isTrue()
+    }
+
+    // ---------- 멱등성 ----------
+    @Test
+    @DisplayName("멱등성 - 같은 키 재요청 시 예약은 1건만 생성되고 동일 응답 반환")
+    fun `멱등성 키 재요청`() {
+        saveMember("alice", credit = 300_000)
+        val scheduleId = saveScheduleWithSeats(price = 10_000, seatNumbers = listOf("A1"))
+        val req = request(scheduleId, listOf("A1"))
+        val key = "idem-key-1"
+
+        val first = reserveApplicationService.reserveSeat(req, "alice", key)
+        val second = reserveApplicationService.reserveSeat(req, "alice", key)
+
+        assertThat(first.statusCode.value()).isEqualTo(200)
+        assertThat(second.statusCode.value()).isEqualTo(200)
+        assertThat(second.body).isEqualTo(first.body) // 캐시된 동일 응답
+
+        // 예약은 한 번만, 크레딧도 한 번만 차감
+        assertThat(reserveRepository.findByMemberUsernameAndStatus("alice", ReserveStatus.RESERVED)).hasSize(1)
+        assertThat(creditOf("alice")).isEqualTo(290_000)
+    }
+}

--- a/src/test/kotlin/com/example/reserve/support/IntegrationTestSupport.kt
+++ b/src/test/kotlin/com/example/reserve/support/IntegrationTestSupport.kt
@@ -1,0 +1,129 @@
+package com.example.reserve.support
+
+import com.example.reserve.idempotency.IdempotencyRepository
+import com.example.reserve.member.Member
+import com.example.reserve.member.MemberRepository
+import com.example.reserve.member.Role
+import com.example.reserve.performance.Performance
+import com.example.reserve.performance.repository.PerformanceRepository
+import com.example.reserve.performanceSchedule.PerformanceSchedule
+import com.example.reserve.performanceSchedule.repository.PerformanceScheduleRepository
+import com.example.reserve.reserve.repository.ReserveRepository
+import com.example.reserve.seat.Seat
+import com.example.reserve.seat.repository.SeatRepository
+import com.example.reserve.venue.Venue
+import com.example.reserve.venue.VenueRepository
+import jakarta.mail.Session
+import jakarta.mail.internet.MimeMessage
+import org.junit.jupiter.api.BeforeEach
+import org.mockito.BDDMockito.given
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection
+import org.springframework.mail.javamail.JavaMailSender
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.support.TransactionTemplate
+import org.testcontainers.containers.MySQLContainer
+import org.testcontainers.utility.DockerImageName
+import java.time.LocalDateTime
+import java.util.Properties
+
+/**
+ * 통합 테스트 베이스
+ *
+ * - 실제 MySQL 컨테이너로 비관적 락/조건부 UPDATE/멱등성을 충실히 검증
+ * - 동시성 테스트는 스레드별 실제 커밋이 필요하므로 @Transactional 롤백을 쓰지 않고, 매 테스트 전 수동으로 전체 삭제 진행
+ * - JavaMailSender는 mock으로 대체해 실제 SMTP 연결을 차단
+ */
+@SpringBootTest
+abstract class IntegrationTestSupport {
+
+    companion object {
+        @JvmStatic
+        @ServiceConnection
+        val mysql: MySQLContainer<*> = MySQLContainer(DockerImageName.parse("mysql:8.0")).apply { start() }
+    }
+
+    @Autowired protected lateinit var venueRepository: VenueRepository
+    @Autowired protected lateinit var performanceRepository: PerformanceRepository
+    @Autowired protected lateinit var performanceScheduleRepository: PerformanceScheduleRepository
+    @Autowired protected lateinit var seatRepository: SeatRepository
+    @Autowired protected lateinit var memberRepository: MemberRepository
+    @Autowired protected lateinit var reserveRepository: ReserveRepository
+    @Autowired protected lateinit var idempotencyRepository: IdempotencyRepository
+
+    @Autowired private lateinit var transactionManager: PlatformTransactionManager
+
+    // 실제 Gmail SMTP 연결 차단
+    @MockitoBean protected lateinit var mailSender: JavaMailSender
+
+    protected val txTemplate: TransactionTemplate by lazy { TransactionTemplate(transactionManager) }
+
+    @BeforeEach
+    fun setUpBase() {
+        // mock 메일 발송이 NPE 없이 동작하도록 매 호출마다 빈 MimeMessage 반환
+        given(mailSender.createMimeMessage()).willAnswer { MimeMessage(Session.getInstance(Properties())) }
+
+        // FK 안전 순서로 전체 삭제 (롤백 대신 수동 정리)
+        seatRepository.deleteAll()
+        reserveRepository.deleteAll()
+        idempotencyRepository.deleteAll()
+        performanceScheduleRepository.deleteAll()
+        performanceRepository.deleteAll()
+        venueRepository.deleteAll()
+        memberRepository.deleteAll()
+    }
+
+    // --- 픽스처 헬퍼 ---
+    protected fun saveMember(
+        username: String,
+        credit: Long = 300_000,
+        reward: Long = 0,
+    ): Member = memberRepository.save(
+        Member(
+            username = username,
+            password = "encoded-password",
+            name = "테스터-$username",
+            role = Role.MEMBER,
+            email = "$username@test.com",
+            credit = credit,
+            reward = reward,
+        )
+    )
+
+    /**
+     * 공연장 + 공연 + 일정 + 좌석을 한 번에 생성하고 scheduleId를 반환
+     * 기본 startTime은 미래(취소 가능)로 설정
+     */
+    protected fun saveScheduleWithSeats(
+        price: Long = 10_000,
+        seatNumbers: List<String> = listOf("A1"),
+        startTime: LocalDateTime = LocalDateTime.now().plusDays(7),
+    ): Long {
+        val venue = venueRepository.save(Venue(name = "테스트 공연장", location = "서울"))
+        val performance = performanceRepository.save(
+            Performance(type = "콘서트", title = "테스트 공연", duration = 120, price = price)
+        )
+        val schedule = performanceScheduleRepository.save(
+            PerformanceSchedule(
+                venue = venue,
+                performance = performance,
+                startTime = startTime,
+                endTime = startTime.plusHours(2),
+            )
+        )
+        seatRepository.saveAll(seatNumbers.map { Seat(seatNumber = it, performanceSchedule = schedule) })
+        return schedule.id!!
+    }
+
+    // 좌석 점유 여부 (트랜잭션 안에서 조회해 lazy 접근 안전)
+    protected fun isSeatReserved(scheduleId: Long, seatNumber: String): Boolean =
+        txTemplate.execute {
+            seatRepository.findByPerformanceScheduleIdAndSeatNumber(scheduleId, seatNumber)?.isReserved ?: false
+        }!!
+
+    protected fun creditOf(username: String): Long = memberRepository.findByUsername(username)!!.credit
+
+    protected fun rewardOf(username: String): Long = memberRepository.findByUsername(username)!!.reward
+}


### PR DESCRIPTION
- Testcontainers MySQL 기반 통합 테스트 환경 구축
- 단일스레드 시나리오 12개(예약/취소/멱등성)
- 동시성 레이스 4개(좌석 선점/크레딧 직렬화/이중 취소 방지/멱등성)