### PR TITLE
refactor 멱등성 예약 처리를 단일 트랜잭션으로 통합

### DIFF
--- a/src/main/kotlin/com/example/reserve/idempotency/IdempotencyExecutor.kt
+++ b/src/main/kotlin/com/example/reserve/idempotency/IdempotencyExecutor.kt
@@ -11,18 +11,33 @@ class IdempotencyExecutor(
     private val objectMapper: ObjectMapper
 ) {
 
-    // task 실행과 COMPLETED 전환을 한 트랜잭션으로 원자화
-    // reserve()의 @Transactional(REQUIRED)이 이 트랜잭션에 합류 → 예약과 멱등성 확정이 함께 커밋
+    // PENDING 선점 + task 실행 + COMPLETED 확정을 단일 트랜잭션으로 묶어 예약 1건당 커밋을 1회로 단축
+    // ( 기존: PENDING 을 별도 트랜잭션으로 선커밋(commit 1) 후 task+COMPLETED(commit 2) → 커밋 2회 )
+    //
+    // 동시 동일키는 unique INSERT 가 직렬화 : 선행 tx가 커밋(또는 롤백)할 때까지 후행 INSERT 가 블록되고
+    // , 선행이 커밋하면 후행은 중복키 예외 → 호출측에서 캐시 응답으로 귀결된다.
+    // ( 선행이 실패해 롤백되면 PENDING 행도 함께 사라지므로 후행이 정상 선점·실행한다 = 실패는 키를 막지 않음 )
+    // PENDING 행은 커밋 전까지 외부 트랜잭션에 보이지 않으므로, 노출되는 멱등 상태는 항상 COMPLETED 뿐
     @Transactional
-    fun runAndComplete(pending: Idempotency, task: () -> Any): String {
-        val response = task()
-        val json = objectMapper.writeValueAsString(response)
+    fun insertRunComplete(idempotencyKey: String, httpMethod: String, task: () -> Any): String {
+        // saveAndFlush 로 즉시 INSERT → 중복키면 여기서 DataIntegrityViolationException 발생 ( 이후 task 미실행 )
+        val idempotency = idempotencyRepository.saveAndFlush(
+            Idempotency(
+                idempotencyKey = idempotencyKey,
+                httpMethod = httpMethod,
+                status = IdempotencyStatus.PENDING,
+                expiresAt = LocalDateTime.now().plusMinutes(Idempotency.EXPIRATION_MINUTES)
+            )
+        )
 
-        pending.status = IdempotencyStatus.COMPLETED
-        pending.statusCode = 200
-        pending.responseBody = json
-        pending.expiresAt = LocalDateTime.now().plusMinutes(Idempotency.EXPIRATION_MINUTES)
-        idempotencyRepository.save(pending)   // detached → merge → UPDATE (같은 트랜잭션)
+        // task(reserve())는 @Transactional(REQUIRED)로 이 트랜잭션에 합류 → 예약과 멱등 확정이 함께 단일 커밋
+        val json = objectMapper.writeValueAsString(task())
+
+        // 같은 트랜잭션 내 managed 엔티티 → 변경 감지로 COMPLETED UPDATE가 커밋 시 함께 flush 됨
+        idempotency.status = IdempotencyStatus.COMPLETED
+        idempotency.statusCode = 200
+        idempotency.responseBody = json
+        idempotency.expiresAt = LocalDateTime.now().plusMinutes(Idempotency.EXPIRATION_MINUTES)
 
         return json
     }

--- a/src/main/kotlin/com/example/reserve/idempotency/IdempotencyService.kt
+++ b/src/main/kotlin/com/example/reserve/idempotency/IdempotencyService.kt
@@ -19,49 +19,35 @@ class IdempotencyService(
         task: () -> Any
     ): ResponseEntity<String> {
 
-        // 1. 기존 이력 확인
+        // 1. 기존 이력 확인 ( 완료/처리중 replay 빠른 경로 )
         val existing = idempotencyRepository.findByIdempotencyKey(idempotencyKey)
-        if (existing != null) { // 기존 이력이 존재한다면
-            // 만료된 키는 삭제 후 재선점 ( 크래시로 PENDING 잔존 시에도 만료 후 회수 )
+        if (existing != null) {
             if (existing.expiresAt.isAfter(LocalDateTime.now())) {
                 return resolveExisting(idempotencyKey, existing)
             }
-            idempotencyRepository.delete(existing)
+            idempotencyRepository.delete(existing) // 만료 → 재선점 허용
         }
 
-        // 2. PENDING 선점 ( unique INSERT = 동시 진입 상호배제 )
-        val pending = try {
-            idempotencyRepository.saveAndFlush(
-                Idempotency(
-                    idempotencyKey = idempotencyKey,
-                    httpMethod = httpMethod,
-                    status = IdempotencyStatus.PENDING,
-                    expiresAt = LocalDateTime.now().plusMinutes(Idempotency.EXPIRATION_MINUTES)
-                )
-            )
-        } catch (e: DataIntegrityViolationException) {
-            // 경쟁 요청이 먼저 선점 → 재조회 후 처리
-            log.info { "멱등성 키 선점 경합 감지 - 키: $idempotencyKey" }
-            val winner = idempotencyRepository.findByIdempotencyKey(idempotencyKey) ?: throw e // 극히 드문 레이스(직후 삭제됨) → 일시적 에러로 재전파
-            return resolveExisting(idempotencyKey, winner)
-        }
-
-        // 3. 선점 성공 → task + COMPLETED 전환을 한 트랜잭션으로 원자화 (별도 빈 위임)
+        // 2. 선점 + 실행 + 완료를 단일 트랜잭션으로 ( 커밋 1회 )
         return try {
-            val successJson = idempotencyExecutor.runAndComplete(pending, task)
+            val successJson = idempotencyExecutor.insertRunComplete(idempotencyKey, httpMethod, task)
             log.info { "멱등성 키 저장 (성공) - 키: $idempotencyKey" }
 
             ResponseEntity.ok(successJson)
 
-        } catch (e: Exception) {
-            // 일시적 에러는 캐싱하지 않고 선점 해제 후 그대로 던짐 ( 재시도 가능 )
-            if (isTransientError(e)) {
-                idempotencyRepository.delete(pending)
-                throw e
-            }
+        } catch (e: DataIntegrityViolationException) {
+            // 동시 동일키 경합 / 레이스 : 선행자가 이미 선점 또는 완료 → 재조회 후 캐시 응답
+            log.info { "멱등성 키 선점 경합 감지 - 키: $idempotencyKey" }
+            val winner = idempotencyRepository.findByIdempotencyKey(idempotencyKey)
+                ?: throw e
+            resolveExisting(idempotencyKey, winner)
 
-            handleException(pending, e)
+        } catch (e: ReserveException) {
+            // 비즈니스 에러: 단일 tx 롤백으로 예약/멱등행이 모두 원복됨 → 캐시 없이 동일 응답 형식으로 반환 ( 재시도 가능 )
+            log.error(e) { "멱등성 처리 비즈니스 에러 - 키: $idempotencyKey, 에러: ${e.errorCode.name}" }
+            ResponseEntity.status(e.status.value()).body(e.errorCode.name)
         }
+        // 그 외 일시적 예외: 롤백되어 그대로 전파 → 재시도 가능 ( 캐시하지 않음 )
     }
 
     // 이미 존재하는 이력에 대한 응답 결정
@@ -70,7 +56,7 @@ class IdempotencyService(
         idempotency: Idempotency
     ): ResponseEntity<String> {
         return when (idempotency.status) {
-            // COMPLETED : 중복 요청
+            // COMPLETED : 중복 요청 → 캐시된 동일 응답
             IdempotencyStatus.COMPLETED -> {
                 log.info { "동일한 중복 요청 감지 - 키: $idempotencyKey" }
 
@@ -79,42 +65,12 @@ class IdempotencyService(
                     .body(idempotency.responseBody!!)
             }
 
-            // 아직 처리 중 → 409 즉시 반환 ( 클라이언트 재시도 )
+            // 단일 커밋 설계에선 커밋된 PENDING 이 외부에 노출되지 않으므로 사실상 도달하지 않음 ( 방어적 처리 )
             IdempotencyStatus.PENDING -> {
                 log.info { "처리 중인 중복 요청 감지 - 키: $idempotencyKey" }
+
                 ResponseEntity.status(409).body("PROCESSING")
             }
         }
-    }
-
-    private fun handleException(
-        pending: Idempotency,
-        e: Exception
-    ): ResponseEntity<String> {
-        val (status, errorCode) = when (e) {
-            is ReserveException -> e.status.value() to e.errorCode.name
-            else -> 500 to "INTERNAL_SERVER_ERROR"
-        }
-
-        complete(pending, status, errorCode)
-        log.error(e) { "멱등성 키 저장 (실패) - 키: ${pending.idempotencyKey}, 에러: $errorCode" }
-
-        return ResponseEntity
-            .status(status)
-            .body(errorCode)
-    }
-
-    // PENDING → COMPLETED 로 응답 확정
-    private fun complete(pending: Idempotency, status: Int, body: String) {
-        pending.status = IdempotencyStatus.COMPLETED
-        pending.statusCode = status
-        pending.responseBody = body
-        pending.expiresAt = LocalDateTime.now().plusMinutes(Idempotency.EXPIRATION_MINUTES)
-
-        idempotencyRepository.save(pending)
-    }
-
-    private fun isTransientError(e: Exception): Boolean {
-        return e !is ReserveException  // ReserveException은 비즈니스 에러 → 캐싱
     }
 }


### PR DESCRIPTION
- PENDING 선점·task 실행·COMPLETED 확정을 한 트랜잭션 1회 커밋으로 단축 (기존 2회 커밋)
- 동시 동일키 경합을 unique INSERT 직렬화로 처리하도록 흐름 단순화